### PR TITLE
added a line to the authCheck service that sets rootScope.bg to false…

### DIFF
--- a/client/dist/services/services.js
+++ b/client/dist/services/services.js
@@ -1,8 +1,10 @@
 'use strict';
 
-angular.module('quizApp').service('authCheck', function ($http, $state, $window) {
+angular.module('quizApp').service('authCheck', function ($http, $state, $window, $rootScope) {
   this.auth = function () {
-    $http.post('/questions', { token: $window.localStorage.accessToken }).then(function (res) {}, function (res) {
+    $http.post('/questions', { token: $window.localStorage.accessToken }).then(function (res) {
+      $rootScope.bg = false;
+    }, function (res) {
       $state.go('signin');
     });
   };

--- a/client/src/services/services.js
+++ b/client/src/services/services.js
@@ -1,8 +1,9 @@
 angular.module('quizApp')
-  .service('authCheck', function($http, $state, $window){
+  .service('authCheck', function($http, $state, $window, $rootScope){
     this.auth = function() {
       $http.post('/questions', {token:$window.localStorage.accessToken})
       .then((res) => {
+        $rootScope.bg = false;
       },(res) => {
         $state.go('signin');
       });


### PR DESCRIPTION
… if auth is successful.  This fixed the bug of the back ground reverting to the city on refresh